### PR TITLE
Add post-6.43 login support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -88,7 +88,8 @@ func TestDialInvalidPort(t *testing.T) {
 		c.Close()
 		t.Fatalf("Dial succeeded; want error")
 	}
-	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." {
+	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." &&
+		err.Error() != "dial tcp: lookup tcp/xxx: Servname not supported for ai_socktype" {
 		t.Fatal(err)
 	}
 }
@@ -99,7 +100,8 @@ func TestDialTLSInvalidPort(t *testing.T) {
 		c.Close()
 		t.Fatalf("Dial succeeded; want error")
 	}
-	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." {
+	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." &&
+		err.Error() != "dial tcp: lookup tcp/xxx: Servname not supported for ai_socktype" {
 		t.Fatal(err)
 	}
 }
@@ -114,7 +116,8 @@ func TestInvalidLogin(t *testing.T) {
 		c.Close()
 		t.Fatalf("Dial succeeded; want error")
 	}
-	if err.Error() != "from RouterOS device: cannot log in" {
+	if err.Error() != "from RouterOS device: cannot log in" &&
+		err.Error() != "from RouterOS device: invalid user name or password (6)" {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
After the routeros version 6.43, there is a new authorization method.
[https://wiki.mikrotik.com/wiki/Manual:API#Initial_login](https://wiki.mikrotik.com/wiki/Manual:API#Initial_login)

An error message has been changed too.
