### PR TITLE
Add post-6.43 login support

### DIFF
--- a/client.go
+++ b/client.go
@@ -107,14 +107,20 @@ func (c *Client) Close() {
 
 // Login runs the /login command. Dial and DialTLS call this automatically.
 func (c *Client) Login(username, password string) error {
-	r, err := c.Run("/login")
+	r, err := c.Run("/login", "=name="+username, "=password="+password)
 	if err != nil {
 		return err
 	}
 	ret, ok := r.Done.Map["ret"]
 	if !ok {
+		// Login method post-6.43 one stage, cleartext and no challenge
+		if r.Done != nil {
+			return nil
+		}
 		return errors.New("RouterOS: /login: no ret (challenge) received")
 	}
+
+	// Login method pre-6.43 two stages, challenge
 	b, err := hex.DecodeString(ret)
 	if err != nil {
 		return fmt.Errorf("RouterOS: /login: invalid ret (challenge) hex string received: %s", err)

--- a/client_test.go
+++ b/client_test.go
@@ -90,7 +90,8 @@ func TestDialInvalidPort(t *testing.T) {
 		c.Close()
 		t.Fatalf("Dial succeeded; want error")
 	}
-	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." {
+	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." &&
+		err.Error() != "dial tcp: lookup tcp/xxx: Servname not supported for ai_socktype" {
 		t.Fatal(err)
 	}
 }
@@ -101,7 +102,8 @@ func TestDialTLSInvalidPort(t *testing.T) {
 		c.Close()
 		t.Fatalf("Dial succeeded; want error")
 	}
-	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." {
+	if err.Error() != "dial tcp: lookup tcp/xxx: getaddrinfow: The specified class was not found." &&
+		err.Error() != "dial tcp: lookup tcp/xxx: Servname not supported for ai_socktype" {
 		t.Fatal(err)
 	}
 }
@@ -140,7 +142,8 @@ func TestInvalidLogin(t *testing.T) {
 		c.Close()
 		t.Fatalf("Dial succeeded; want error")
 	}
-	if err.Error() != "from RouterOS device: cannot log in" {
+	if err.Error() != "from RouterOS device: cannot log in" &&
+		err.Error() != "from RouterOS device: invalid user name or password (6)" {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
After the routeros version 6.43, there is a new authorization method.
[https://wiki.mikrotik.com/wiki/Manual:API#Initial_login](https://wiki.mikrotik.com/wiki/Manual:API#Initial_login)

An error message has been changed too.
