### PR TITLE
Simplify tests (on master)

### DIFF
--- a/proto/writer_test.go
+++ b/proto/writer_test.go
@@ -17,7 +17,7 @@ func TestEncodeLength(t *testing.T) {
 		{0x10000080, []byte{0xF0, 0x10, 0x00, 0x00, 0x80}},
 	} {
 		b := encodeLength(d.length)
-		if bytes.Compare(b, d.rawBytes) != 0 {
+		if !bytes.Equal(b, d.rawBytes) {
 			t.Fatalf("Expected output %#v for len=%d, got %#v", d.rawBytes, d.length, b)
 		}
 	}

--- a/proto_test.go
+++ b/proto_test.go
@@ -1,7 +1,6 @@
 package routeros_test
 
 import (
-	"fmt"
 	"io"
 	"testing"
 
@@ -166,7 +165,7 @@ func TestRunWithListen(t *testing.T) {
 
 	sen := <-listen.Chan()
 	want := "!re @l1 [{`address` `1.2.3.4/32`}]"
-	if fmt.Sprintf("%s", sen) != want {
+	if sen.String() != want {
 		t.Fatalf("/ip/address (%s); want (%s)", sen, want)
 	}
 
@@ -377,7 +376,7 @@ func TestListen(t *testing.T) {
 
 	sen := <-reC
 	want := "!re @l1 [{`address` `1.2.3.4/32`}]"
-	if fmt.Sprintf("%s", sen) != want {
+	if sen.String() != want {
 		t.Fatalf("/ip/address/listen (%s); want (%s)", sen, want)
 	}
 


### PR DESCRIPTION
- should use String() instead of fmt.Sprintf
- should use !bytes.Equal(b, d.rawBytes) instead