### PR TITLE
Fix handling command response when !trap is received

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -121,3 +121,16 @@ func TestInvalidLogin(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestTrapHandling(tt *testing.T) {
+	t := newLiveTest(tt)
+	defer t.c.Close()
+
+	cmd := []string{"/ip/dns/static/add", "=type=A", "=name=example.com", "=ttl=30", "=address=1.0.0.0"}
+
+	_, _ = t.c.RunArgs(cmd)
+	_, err := t.c.RunArgs(cmd)
+	if err == nil {
+		t.Fatal("Should've returned an error due to a duplicate")
+	}
+}


### PR DESCRIPTION
Even though `!trap` message returns an error, command still completes with the `!done` sentence sent right after `!trap`, which needs to be processed too.

Only `!fatal` will not send anything after because the remote site is closing connection anyway (as per [documentation](https://wiki.mikrotik.com/wiki/API_command_notes#.21fatal)):
> `!fatal` can be received only in cases when API is closing connection:

In synchronous mode, if not processed, it clashes with the next command and wrong reply is processed.