### PR TITLE
feat: Add new `!empty` sentence for RouterOS 7.18+

### DIFF
--- a/listen.go
+++ b/listen.go
@@ -13,6 +13,7 @@ const (
 	doneSentence  = "!done"
 	trapSentence  = "!trap"
 	reSentence    = "!re"
+	emptySentence = "!empty"
 )
 
 // ListenReply is the struct returned by the Listen*() functions.
@@ -125,7 +126,7 @@ func (l *ListenReply) processSentence(sen *proto.Sentence) (bool, error) {
 		return true, &DeviceError{sen}
 	case fatalSentence:
 		return true, &DeviceError{sen}
-	case "":
+	case "", emptySentence:
 		// API docs say that empty sentences should be ignored
 	default:
 		return true, &UnknownReplyError{sen}

--- a/reply.go
+++ b/reply.go
@@ -35,7 +35,7 @@ func (r *Reply) processSentence(sen *proto.Sentence) (bool, error) {
 		return true, nil
 	case trapSentence, fatalSentence:
 		return sen.Word == fatalSentence, &DeviceError{sen}
-	case "":
+	case "", emptySentence:
 		// API docs say that empty sentences should be ignored
 	default:
 		return true, &UnknownReplyError{sen}


### PR DESCRIPTION
Alexander, hey!

In the next MT release the module will stop working, because since version 7.18 the developers have added a new control word [`!empty`](https://mikrotik.com/download/changelogs). 
```
*) console - put !empty sentence when API query returns nothing;
```
I added it to two functions with backward compatibility. Please consider a PR, as I currently have the Terraform module [no longer working](https://github.com/terraform-routeros/terraform-provider-routeros/issues/661).

I tested the working locally. And everything seems to be fine.

Thanks for the module!
